### PR TITLE
Fix not allocating enough space for NULL

### DIFF
--- a/src/strings/ft_strsplit.c
+++ b/src/strings/ft_strsplit.c
@@ -40,7 +40,7 @@ char		**ft_strsplit(char const *s, char c)
 	size_t	stopper;
 
 	if (!s || !(array = (char **)malloc(sizeof(char *)
-	* ft_len(s, c) + sizeof(char))))
+	* ft_len(s, c) + sizeof(char*))))
 		return (NULL);
 	i = 0;
 	j = 0;


### PR DESCRIPTION
Was causing this to happen:
```
==8967== Invalid write of size 8
==8967==    at 0x11B282: ft_strsplit (ft_strsplit.c:59)
==8967==    by 0x10C852: autocomplete_from_path (get_autocomplete_commands.c:85)
==8967==    by 0x10C985: get_autocomplete_commands (get_autocomplete_commands.c:115)
==8967==    by 0x10A9F8: shell (main.c:85)
==8967==    by 0x10AB3C: main (main.c:106)
```

Which then caused other problems:
```
==8967==  Address 0x4a7fe58 is 104 bytes inside a block of size 105 alloc'd
==8967==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==8967==    by 0x11B182: ft_strsplit (ft_strsplit.c:42)
==8967==    by 0x10C852: autocomplete_from_path (get_autocomplete_commands.c:85)
==8967==    by 0x10C985: get_autocomplete_commands (get_autocomplete_commands.c:115)
==8967==    by 0x10A9F8: shell (main.c:85)
==8967==    by 0x10AB3C: main (main.c:106)
==8967== 
==8967== Conditional jump or move depends on uninitialised value(s)
==8967==    at 0x10C8B1: autocomplete_from_path (get_autocomplete_commands.c:89)
==8967==    by 0x10C985: get_autocomplete_commands (get_autocomplete_commands.c:115)
==8967==    by 0x10A9F8: shell (main.c:85)
==8967==    by 0x10AB3C: main (main.c:106)
==8967== 
==8967== Conditional jump or move depends on uninitialised value(s)
==8967==    at 0x483C9F5: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==8967==    by 0x10C8D9: autocomplete_from_path (get_autocomplete_commands.c:92)
==8967==    by 0x10C985: get_autocomplete_commands (get_autocomplete_commands.c:115)
==8967==    by 0x10A9F8: shell (main.c:85)
==8967==    by 0x10AB3C: main (main.c:106)
```

This change fixes all the above Valgrind errors